### PR TITLE
Add RadioSwitch and default mood fallback

### DIFF
--- a/config-sample.json
+++ b/config-sample.json
@@ -27,6 +27,7 @@
         "Valve": "Valve",
         "Sprinklers": "Sprinklers",
         "Fan": "Fan",
-        "Lock": "Lock"
+        "Lock": "Lock",
+        "DefaultMood": "Off"
     }
 }

--- a/config.schema.json
+++ b/config.schema.json
@@ -118,6 +118,9 @@
                     },
                     "Lock": {
                         "type": "string"
+                    },
+                    "DefaultMood": {
+                        "type": "string"
                     }
                 }
             }

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ module.exports = homebridge => {
     Utility.addSupportTo(ItemFactory.Switch, ItemFactory.AbstractItem);
     Utility.addSupportTo(ItemFactory.SmokeSensor, ItemFactory.AbstractItem);
     Utility.addSupportTo(ItemFactory.Alarm, ItemFactory.AbstractItem);
+    Utility.addSupportTo(ItemFactory.RadioSwitchItem, ItemFactory.AbstractItem);
     Utility.addSupportTo(ItemFactory.Lock, ItemFactory.AbstractItem);
     Utility.addSupportTo(ItemFactory.Valve, ItemFactory.AbstractItem);
 
@@ -118,7 +119,7 @@ function LoxPlatform(log, config) {
     }
     const alias = config['alias'];
 
-    let aliases = ['Outlet', 'Lighting', 'Doorbell', 'Trigger', 'Contact', 'Motion', 'Brightness', 'Temperature', 'Humidity', 'Lock', 'Valve', 'Sprinklers', 'Fan', 'Leak'];
+    let aliases = ['Outlet', 'Lighting', 'Doorbell', 'Trigger', 'Contact', 'Motion', 'Brightness', 'Temperature', 'Humidity', 'Lock', 'Valve', 'Sprinklers', 'Fan', 'Leak', 'DefaultMood'];
 
     aliases.forEach(function (item) {
         if (!alias[item]) {
@@ -139,7 +140,8 @@ LoxPlatform.prototype.accessories = function (callback) {
     const url = itemFactory.sitemapUrl();
     this.log("Platform - Waiting 8 seconds until initial state is retrieved via WebSocket.");
     setTimeout(() => {
-        that.log(`Platform - Retrieving initial config from ${url}`);
+        const anonymizedUrl = url.substr(0, url.indexOf("//")) + "//"+ url.substr(url.indexOf("@") + 1);
+        that.log(`Platform - Retrieving initial config from ${anonymizedUrl}`);
         request.get({
             url,
             json: true

--- a/items/LightControllerV2MoodSwitchItem.js
+++ b/items/LightControllerV2MoodSwitchItem.js
@@ -1,33 +1,37 @@
-const request = require("request");
+"use strict";
 
-const LightControllerV2MoodSwitchItem = function(widget,platform,homebridge) {
+var LightControllerV2MoodSwitchItem = function (widget, platform, homebridge) {
     this.platform = platform;
     this.uuidAction = widget.uuidAction;
     this.stateUuidActiveMoods = widget.states.activeMoods;
     this.mood = widget.mood;
+    this.defaultMood = widget.defaultMood;
     this.uuidActionOriginal = widget.uuidActionOriginal;
 
-    this.currentState = undefined; 
+    this.currentState = undefined;
 
-    LightControllerV2MoodSwitchItem.super_.call(this, widget,platform,homebridge);
+    LightControllerV2MoodSwitchItem.super_.call(this, widget, platform, homebridge);
 };
 
 // Register a listener to be notified of changes in this items value
-LightControllerV2MoodSwitchItem.prototype.initListener = function() {
+LightControllerV2MoodSwitchItem.prototype.initListener = function () {
     this.platform.ws.registerListenerForUUID(this.stateUuidActiveMoods, this.callBackActiveMoods.bind(this));
 };
 
-LightControllerV2MoodSwitchItem.prototype.callBackActiveMoods = function(value) {
-    this.currentState = (value.indexOf(this.mood.id) > -1);
-    //console.log('Mood ' + this.mood.name + ': IsOn? ' + this.currentState);
+LightControllerV2MoodSwitchItem.prototype.callBackActiveMoods = function (value) {
+    // value is string containing array of active moods eg. "[1,3]"
+    const sanitized = value.slice(1, -1).split(",")
+
+    this.currentState = sanitized.some(active => active == this.mood.id) || false;
+    // this.log('Mood ' + this.mood.name + ': IsOn? ' + this.currentState);
 
     this.otherService
         .getCharacteristic(this.homebridge.hap.Characteristic.On)
         .updateValue(this.currentState);
 };
 
-LightControllerV2MoodSwitchItem.prototype.getOtherServices = function() {
-    const otherService = new this.homebridge.hap.Service.Switch();
+LightControllerV2MoodSwitchItem.prototype.getOtherServices = function () {
+    var otherService = new this.homebridge.hap.Service.Switch();
 
     otherService.getCharacteristic(this.homebridge.hap.Characteristic.On)
         .on('set', this.setItemState.bind(this))
@@ -36,11 +40,11 @@ LightControllerV2MoodSwitchItem.prototype.getOtherServices = function() {
     return otherService;
 };
 
-LightControllerV2MoodSwitchItem.prototype.getItemState = function(callback) {
+LightControllerV2MoodSwitchItem.prototype.getItemState = function (callback) {
     callback(undefined, this.currentState);
 };
 
-LightControllerV2MoodSwitchItem.prototype.setItemState = function(value, callback) {
+LightControllerV2MoodSwitchItem.prototype.setItemState = function (value, callback) {
     if (value == true) {
         // update local state
         this.currentState = true;
@@ -53,14 +57,22 @@ LightControllerV2MoodSwitchItem.prototype.setItemState = function(value, callbac
         //this.log("[LightControllerV2MoodSwitch] Send message to " + this.name + "uuidAction: '" + this.uuidActionOriginal + "' Command: '" + command + "'");
         this.platform.ws.sendCommand(this.uuidActionOriginal, command);
 
-    } else if (this.currentState == true) {
-        //this.log("[LightControllerV2MoodSwitch] Asking to be turned off, but it's currently on, need to cancel. " + this.name + "uuidAction: '" + this.uuidActionOriginal);
+    } else {
+        if (this.currentState == true) {
+            // keep previous state if defaultMood is not available, otherwise switch to it
+            this.currentState = this.defaultMood ? false : true;
+            this.otherService
+                .getCharacteristic(this.homebridge.hap.Characteristic.On)
+                .setValue(this.currentState);
 
-        // if we are trying to turn this Off, and we're currently On, then we cancel the action
-        this.otherService
-            .getCharacteristic(this.homebridge.hap.Characteristic.On)
-            .setValue(this.currentState);
+            if (this.defaultMood) {
+                // send the mood change command to Loxone
+                const command = `changeTo/${this.defaultMood.id}`;
+                // this.log("[LightControllerV2MoodSwitch] Send message to " + this.name + "uuidAction: '" + this.uuidActionOriginal + "' Command: '" + command + "'");
+                this.platform.ws.sendCommand(this.uuidActionOriginal, command);
+            }
 
+        }
     }
 
     callback();

--- a/items/RadioSwitchItem.js
+++ b/items/RadioSwitchItem.js
@@ -1,0 +1,81 @@
+"use strict";
+
+var request = require("request");
+
+const DEFAULT_SWITCH_ID = 0
+
+var RadioSwitchItem = function (widget, platform, homebridge) {
+    this.platform = platform;
+    this.uuidAction = widget.uuidAction;    // this is a dummy uuidAction
+    this.stateUuidActiveOutput = widget.states.activeOutput;
+    this.radio = widget.radio;
+    this.uuidActionOriginal = widget.uuidActionOriginal;
+
+    this.currentState = undefined;
+
+    RadioSwitchItem.super_.call(this, widget, platform, homebridge);
+};
+
+// Register a listener to be notified of changes in this items value
+RadioSwitchItem.prototype.initListener = function () {
+    this.platform.ws.registerListenerForUUID(this.stateUuidActiveOutput, this.callBackActiveOutput.bind(this));
+};
+
+RadioSwitchItem.prototype.callBackActiveOutput = function (value) {
+    this.currentState = value == this.radio.id;
+    // console.log('Radio callBackActiveOutput ' + this.name + ': IsOn? ' + this.currentState);
+
+    this.otherService
+        .getCharacteristic(this.homebridge.hap.Characteristic.On)
+        .updateValue(this.currentState);
+};
+
+RadioSwitchItem.prototype.getOtherServices = function () {
+    var otherService = new this.homebridge.hap.Service.Switch();
+
+    otherService.getCharacteristic(this.homebridge.hap.Characteristic.On)
+        .on('set', this.setItemState.bind(this))
+        .on('get', this.getItemState.bind(this))
+
+    return otherService;
+};
+
+RadioSwitchItem.prototype.getItemState = function (callback) {
+    // console.log('Radio getItemState ' + this.name + ': IsOn? ' + this.currentState);
+    callback(undefined, this.currentState);
+};
+
+RadioSwitchItem.prototype.setItemState = function (value, callback) {
+    if (value == true) {
+        // update local state
+        this.currentState = true;
+        this.otherService
+            .getCharacteristic(this.homebridge.hap.Characteristic.On)
+            .updateValue(this.currentState);
+
+        // send the radio output change command to Loxone
+        var command = this.radio.id === DEFAULT_SWITCH_ID ? "reset" : `${this.radio.id}`;
+        // this.log("[RadioSwitchItem] Send message to '" + this.name + "', id: " + this.radio.id + ", Command: '" + command + "'");
+        this.platform.ws.sendCommand(this.uuidActionOriginal, command);
+    } else {
+        // default switch option cannot be switched off since all other switched default to it
+        const canSwitchOff = (this.radio.id !== DEFAULT_SWITCH_ID);
+
+        this.currentState = canSwitchOff ? false : true;
+        this.otherService
+            .getCharacteristic(this.homebridge.hap.Characteristic.On)
+            .updateValue(this.currentState);
+
+        if (canSwitchOff) {
+            // switching off a radio control means reseting it
+            var command = "reset";
+            // this.log("[RadioSwitchItem] Send message to '" + this.name + "', id: " + this.radio.id + ", Command: '" + command + "'");
+            this.platform.ws.sendCommand(this.uuidActionOriginal, command);
+        }
+    }
+
+    callback();
+
+};
+
+module.exports = RadioSwitchItem;

--- a/items/SwitchItem.js
+++ b/items/SwitchItem.js
@@ -1,23 +1,22 @@
-const request = require("request");
-
-const SwitchItem = function(widget,platform,homebridge) {
+const SwitchItem = function (widget, platform, homebridge) {
 
     this.platform = platform;
     this.uuidAction = widget.uuidAction;
     this.stateUuid = widget.states.active;
     this.currentState = undefined;
 
-    SwitchItem.super_.call(this, widget,platform,homebridge);
+    SwitchItem.super_.call(this, widget, platform, homebridge);
 };
 
 // Register a listener to be notified of changes in this items value
-SwitchItem.prototype.initListener = function() {
+SwitchItem.prototype.initListener = function () {
     this.platform.ws.registerListenerForUUID(this.stateUuid, this.callBack.bind(this));
 };
 
-SwitchItem.prototype.callBack = function(value) {
+SwitchItem.prototype.callBack = function (value) {
     //function that gets called by the registered ws listener
     //console.log("Got new state for switch: " + value);
+
     this.currentState = value;
 
     //also make sure this change is directly communicated to HomeKit
@@ -26,7 +25,7 @@ SwitchItem.prototype.callBack = function(value) {
         .updateValue(this.currentState == '1');
 };
 
-SwitchItem.prototype.getOtherServices = function() {
+SwitchItem.prototype.getOtherServices = function () {
     const otherService = new this.homebridge.hap.Service.Switch();
 
     this.item = 'Switch';
@@ -39,23 +38,23 @@ SwitchItem.prototype.getOtherServices = function() {
     return otherService;
 };
 
-SwitchItem.prototype.getItemState = function(callback) {
+SwitchItem.prototype.getItemState = function (callback) {
     //returns true if currentState is 1
     callback(undefined, this.currentState == '1');
 };
 
-SwitchItem.prototype.setItemState = function(value, callback) {
-
+SwitchItem.prototype.setItemState = function (value, callback) {
     //sending new state to loxone
     //added some logic to prevent a loop when the change because of external event captured by callback
-
-    const self = this;
-	
-    const command = (value == '1') ? 'On' : 'Off';
-    this.log(`[${this.item}] - send message to ${this.name}: ${command}`);
-    this.platform.ws.sendCommand(this.uuidAction, command);
+    const newState = Boolean(value);
+    if (newState !== Boolean(this.currentState)) {
+        const command = newState ? 'On' : 'Off';
+        this.log(`[${this.item}] - send message to ${this.name}: ${command}, previous state: ${this.currentState}`);
+        this.platform.ws.sendCommand(this.uuidAction, command);
+    } else {
+        this.log(`[${this.item}] - ignoring state change to ${this.name}: ${newState}, previous state: ${this.currentState}`);
+    }
     callback();
-
 };
 
 module.exports = SwitchItem;


### PR DESCRIPTION
This PR fixes several bugs, improves a support for LightControllerV2 moods and adds new RadioSwitch item.

**RadioSwitch item**
Loxone represents certain options as a selection with radio switches. This new item does not require any specific configuration as the appropriate match is made by comparing an item type to value "Radio".

**LightControllerV2**
Support for default mood has been added. Name of the default mood is provided by "DefaultMood" key in `alias` configuration with default value "Off". Default mood is set whenever current mood is being switched off. This way all mood switches act more like radio switch.

**Fixes**
 - SwitchItem could cause infinite loop by updating its state with current value
 - When starting this plugin logged sensitive information (eg. URL with login and password)
 - Fixed current mood detection in LightControllerV2SwitchItem 